### PR TITLE
Fix CDATA tags and update for ST3

### DIFF
--- a/sane_snippets.py
+++ b/sane_snippets.py
@@ -4,25 +4,33 @@ import os
 import re
 import xml.etree.ElementTree as etree
 try:
-    from io import StringIO
-except ImportError:
     from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+ST2 = int(sublime.version()) < 3000
 
 EXT_SANESNIPPET  = ".sane-snippet"
 EXT_SNIPPET_SANE = ".sane.sublime-snippet"
 
-template      = re.compile(r'''
-                                ---%(nl)s               # initial separator, newline {optional}
-                                (?P<header>.*?)%(nnl)s  # the header, named group for newline
-                                ---%(nl)s               # another separator, newline
-                                (?P<content>.*)         # the content - matches till the end of the string
-                           ''' % dict(nl=r'(?:\r\n?|\n)', nnl=r'(?P<linesep>\r\n?|\n)'),
-                           re.S | re.X)
+template = re.compile(
+    r'''
+        ---%(nl)s               # initial separator, newline {optional}
+        (?P<header>.*?)%(nnl)s  # the header, named group for newline
+        ---%(nl)s               # another separator, newline
+        (?P<content>.*)         # the content - matches till the end of the string
+    '''
+    % dict(nl=r'(?:\r\n?|\n)', nnl=r'(?P<linesep>\r\n?|\n)'),
+    re.S | re.X)
 line_template = re.compile(r'^(?P<key>.*?):\s*(?P<val>.*)$')
 
 
+################################################################################
+# XML dump only part
+
 class ElementTreeCDATA(etree.ElementTree):
     """Subclass of ElementTree which handles CDATA blocks reasonably"""
+    # http://stackoverflow.com/questions/174890
 
     def __init__(self, elem, linesep='\n', *args, **kwargs):
         etree.ElementTree.__init__(self, elem, *args, **kwargs)
@@ -33,22 +41,42 @@ class ElementTreeCDATA(etree.ElementTree):
 
         if node.tag == '![CDATA[':
             text = node.text.encode(encoding)
-
-            # http://stackoverflow.com/questions/223652
-            # ']]>' sequences should be escaped by wrapping them into two CDATA sections
-            # However, this is not supported by ST as of 2220 and 3035. Instead, use a hack with
-            # an undefined variable which ST will replace with ''.
-            # See: https://github.com/SublimeText/UnofficialDocs/pull/29
-            text = text.replace(']]>', ']]$UNDEFIND>')
-            # text = text.replace(']]>', ']]]]><![CDATA[>')
-
-            # Windows seems to replace '\r\n' by '\n' when parsing the regexp (but using only '\n'
-            # in the regexp will fail).
-            # Also, Windows replaces any '\n' write-time by '\r\n'. '\r' works as it should.
-            f.write("%(ls)s<![CDATA[%(text)s]]>%(ls)s" % dict(text=text, ls=self.linesep))
+            f.write(_process_cdata(text, self.linesep))
         else:
             etree.ElementTree._write(self, f, node, encoding, namespaces)
 
+
+def _process_cdata(cdata, linesep='\n'):
+    # http://stackoverflow.com/questions/223652
+    # ']]>' sequences should be escaped by wrapping them into two CDATA sections
+    # However, this is not supported by ST as of 2220 and 3035. Instead, use a hack with
+    # an undefined variable which ST will replace with ''.
+    # See: https://github.com/SublimeText/UnofficialDocs/pull/29
+    cdata = cdata.replace(']]>', ']]$UNDEFINED>')
+    # cdata = cdata.replace(']]>', ']]]]><![CDATA[>')
+
+    # Windows seems to replace '\r\n' by '\n' when parsing the regexp (but using only '\n'
+    # in the regexp will fail).
+    # Also, Windows replaces any '\n' write-time by '\r\n'. '\r' works as it should.
+    # TODO: Remove this, it's probably unnecessary
+    return "%(ls)s<![CDATA[%(cdata)s]]>%(ls)s" % dict(cdata=cdata, ls=linesep)
+
+if hasattr(etree, '_serialize_xml'):
+    etree._original_serialize_xml = etree._serialize_xml
+
+    def _serialize_xml(write, elem, qnames, namespaces):
+        """This method is for ElementTree >= 1.3.0"""
+
+        if elem.tag == '![CDATA[':
+            write(_process_cdata(elem.text))
+        else:
+            etree._original_serialize_xml(write, elem, qnames, namespaces)
+
+    etree._serialize_xml = _serialize_xml
+
+
+################################################################################
+# XML helper functions
 
 def xml_append_node(s, tag, text, **kwargs):
     """This one is tough ..."""
@@ -68,6 +96,10 @@ def snippet_to_xml(snippet):
 
     s.append(xml_append_node(etree.Element('content'), '![CDATA[', snippet['content']))
     return s
+
+
+################################################################################
+# The actual useful functions
 
 
 def parse_snippet(path, name, text):
@@ -141,9 +173,14 @@ def regenerate_snippet(path, onload=False):
     sio = StringIO()
     try:
         # TODO: Prettify the XML structure before writing
-        ElementTreeCDATA(snippet_to_xml(snippet), linesep=snippet['linesep']).write(sio)
+        et = ElementTreeCDATA(snippet_to_xml(snippet), linesep=snippet['linesep'])
+        if ST2:
+            et.write(sio)
+        else:
+            et.write(sio, encoding='unicode')
     except:
         print("SaneSnippet: Could not write XML data into stream for file `%s`" % path)
+        raise
         return None
     else:
         return sio.getvalue()
@@ -216,11 +253,11 @@ def swap_extension(path):
     else:
         return path.replace(EXT_SANESNIPPET, EXT_SNIPPET_SANE)
 
-# Go go gadget snippets! (run async?)
-regenerate_snippets(onload=True)
+
+################################################################################
+# ST interface (event listeners, commands)
 
 
-# Watch for updated snippets
 class SaneSnippet(sublime_plugin.EventListener):
     """Rechecks the view's directory for .sane-snippets and regenerates them,
     if the saved file is a .sane-snippet
@@ -240,3 +277,14 @@ class RegenerateSaneSnippetsCommand(sublime_plugin.WindowCommand):
     If `force = True` it will regenerate all the snippets even if they weren't updated"""
     def run(self, force=True):
         regenerate_snippets(force=force)
+
+
+################################################################################
+# Init
+
+def plugin_loaded():
+    # Go go gadget snippets! (run async?)
+    regenerate_snippets(onload=True)
+
+if ST2:
+    plugin_loaded()


### PR DESCRIPTION
Sublime Text does not recognize the "official" CDATA tag escape mechanism of replacing "]]>" with "]]]]><![CDATA[<" so instead use the workaround (or hack) as described in SublimeText/UnofficialDocs#29.

And while I tested this in ST3 I encountered various problems and exceptions so those are fixed as well now, at least for me.
